### PR TITLE
CMake improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,12 @@
 PROJECT(miniz)
 cmake_minimum_required(VERSION 2.8)
-set(CMAKE_BUILD_TYPE Release)
-set(CMAKE_CONFIGURATION_TYPES Release Debug)
+if(CMAKE_BUILD_TYPE STREQUAL "")
+  # CMake defaults to leaving CMAKE_BUILD_TYPE empty. This screws up
+  # differentiation between debug and release builds.
+  set(CMAKE_BUILD_TYPE "Release" CACHE STRING
+    "Choose the type of build, options are: None (CMAKE_CXX_FLAGS or \
+CMAKE_C_FLAGS used) Debug Release RelWithDebInfo MinSizeRel." FORCE)
+endif ()
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/bin)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-PROJECT(miniz)
+PROJECT(miniz C)
 cmake_minimum_required(VERSION 2.8)
 if(CMAKE_BUILD_TYPE STREQUAL "")
   # CMake defaults to leaving CMAKE_BUILD_TYPE empty. This screws up


### PR DESCRIPTION
Hello!
Thanks for the awesome lightweight library.
I have one issue with it though: I'm adding it to my project using CMake's `add_subdirectory`, and because of forced `CMAKE_BUILD_TYPE` in miniz's CMakeLists.txt, it always builds with `-O3` flag, even when I'm building debug version of my project.
This little PR fixes this behaviour, still leaving default build type to Release (the `CMAKE_BUILD_TYPE STREQUAL ""` clause is related to the case when cmake is run without build type explicitly specified).